### PR TITLE
PT-1132 Feature/format data time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ The Tidepool platform API
 
 ## Unreleased
 ### Added
-- PT-1004: Document the api using openApi and swaggo
+- PT-1004 Document the api using openApi and swaggo
 - PT-1142 Missing index on data/deviceData Mongo collection
+- PT-1132 Parse incoming data objects to make their time correct
 
 ## 0.6.4 2020-02-13
 ### Fixed

--- a/data/types/base.go
+++ b/data/types/base.go
@@ -35,6 +35,7 @@ const (
 	TimeZoneOffsetMaximum   = 7 * 24 * 60  // TODO: Fix! Limit to reasonable values
 	TimeZoneOffsetMinimum   = -7 * 24 * 60 // TODO: Fix! Limit to reasonable values
 	VersionMinimum          = 0
+	parsingTimeFormat       = "2006-01-02T15:04:05.999-0700"
 )
 
 type Base struct {
@@ -250,7 +251,6 @@ func (b *Base) Normalize(normalizer data.Normalizer) {
 		sort.Strings(*b.Tags)
 	}
 	if b.Time != nil && *b.Time != "" {
-		parsingTimeFormat := "2006-01-02T15:04:05.999-0700"
 		parsedTime, err := time.Parse(TimeFormat, *b.Time)
 		if err != nil {
 			parsedTime, err = time.Parse(parsingTimeFormat, *b.Time)
@@ -268,16 +268,14 @@ func (b *Base) Normalize(normalizer data.Normalizer) {
 				}
 			}
 			if b.TimeZoneOffset == nil {
-				offsetSet := false
 				if b.TimeZoneName != nil && *b.TimeZoneName != "" {
 					zoneLoc, err := time.LoadLocation(*b.TimeZoneName)
 					if err == nil {
 						_, offset := parsedTime.UTC().In(zoneLoc).Zone()
 						b.TimeZoneOffset = pointer.FromInt(offset / 60)
-						offsetSet = true
 					}
 				}
-				if offsetSet == false {
+				if b.TimeZoneOffset == nil {
 					b.TimeZoneOffset = pointer.FromInt(0)
 				}
 			}

--- a/data/types/base.go
+++ b/data/types/base.go
@@ -249,6 +249,61 @@ func (b *Base) Normalize(normalizer data.Normalizer) {
 	if b.Tags != nil {
 		sort.Strings(*b.Tags)
 	}
+	if b.Time != nil && *b.Time != "" {
+		parsingTimeFormat := "2006-01-02T15:04:05.999-0700"
+		parsedTime, err := time.Parse(TimeFormat, *b.Time)
+		if err != nil {
+			parsedTime, err = time.Parse(parsingTimeFormat, *b.Time)
+		}
+		if err == nil {
+			utcTimeString := parsedTime.UTC().Format(TimeFormat)
+			_, offset := parsedTime.Zone()
+			// Time field is not well formatted in UTC
+			if utcTimeString != *b.Time {
+				b.Time = pointer.FromString(utcTimeString)
+				// Time field was not set to UTC timezone
+				// we update zone name / zone offset
+				if utcTimeString != parsedTime.Format(TimeFormat) {
+					b.TimeZoneOffset = pointer.FromInt(offset / 60)
+				}
+			}
+			if b.TimeZoneOffset == nil {
+				offsetSet := false
+				if b.TimeZoneName != nil && *b.TimeZoneName != "" {
+					zoneLoc, err := time.LoadLocation(*b.TimeZoneName)
+					if err == nil {
+						_, offset := parsedTime.UTC().In(zoneLoc).Zone()
+						b.TimeZoneOffset = pointer.FromInt(offset / 60)
+						offsetSet = true
+					}
+				}
+				if offsetSet == false {
+					b.TimeZoneOffset = pointer.FromInt(0)
+				}
+			}
+			offsetZone := time.FixedZone("offsetZone", *b.TimeZoneOffset*60)
+			// For TimeZoneName we only check that :
+			// the current timezone offset is valid for the TimeZoneName passed in
+			// if not TimeZoneName is reset to nil
+			if b.TimeZoneName != nil {
+				tzCompareFormat := "15:04:05 -0700"
+				currentZoneName := *b.TimeZoneName
+				zoneLoc, err := time.LoadLocation(currentZoneName)
+				if err == nil {
+					localZoneTime := parsedTime.In(zoneLoc)
+					localOffsetTime := parsedTime.In(offsetZone)
+					if localZoneTime.Format(tzCompareFormat) != localOffsetTime.Format(tzCompareFormat) {
+						b.TimeZoneName = nil
+					}
+				} else {
+					b.TimeZoneName = nil
+				}
+			}
+			// Setting DeviceTime to Time in offset zone (with the correct format)
+			b.DeviceTime = pointer.FromString(parsedTime.UTC().In(offsetZone).Format(DeviceTimeFormat))
+		}
+
+	}
 }
 
 func (b *Base) IdentityFields() ([]string, error) {

--- a/data/types/base_test.go
+++ b/data/types/base_test.go
@@ -962,6 +962,73 @@ var _ = Describe("Base", func() {
 					},
 					nil,
 				),
+				Entry("Time field set with offset, wrong TimeZoneName, wrong TimeZoneOffset",
+					func(datum *types.Base) {
+						datum.Time = pointer.FromString("2020-01-01T15:00:00+0100")
+						datum.TimeZoneName = pointer.FromString("America/Chicago")
+						datum.TimeZoneOffset = pointer.FromInt(0)
+						datum.DeviceTime = pointer.FromString("2020-01-01T15:00:00")
+					},
+					func(datum *types.Base, expectedDatum *types.Base) {
+						expectedDatum.Time = pointer.FromString("2020-01-01T14:00:00Z")
+						expectedDatum.TimeZoneName = nil
+						expectedDatum.TimeZoneOffset = pointer.FromInt(60)
+					},
+				),
+				Entry("Time field set with offset , correct TimeZoneName and wrong TimeZoneOffset",
+					func(datum *types.Base) {
+						datum.Time = pointer.FromString("2020-01-01T15:00:00-0600")
+						datum.TimeZoneName = pointer.FromString("America/Chicago")
+						datum.TimeZoneOffset = pointer.FromInt(0)
+						datum.DeviceTime = pointer.FromString("2020-01-01T15:00:00")
+					},
+					func(datum *types.Base, expectedDatum *types.Base) {
+						expectedDatum.Time = pointer.FromString("2020-01-01T21:00:00Z")
+						expectedDatum.TimeZoneName = pointer.FromString("America/Chicago")
+						expectedDatum.TimeZoneOffset = pointer.FromInt(-360)
+					},
+				),
+				Entry("Time field set with malformed UTC, correct TimeZoneName, correct TimeZoneOffset",
+					func(datum *types.Base) {
+						datum.Time = pointer.FromString("2020-01-01T15:00:00+0000")
+						datum.TimeZoneName = pointer.FromString("America/Chicago")
+						datum.TimeZoneOffset = pointer.FromInt(-360)
+						datum.DeviceTime = pointer.FromString("2020-01-01T09:00:00")
+					},
+					func(datum *types.Base, expectedDatum *types.Base) {
+						expectedDatum.Time = pointer.FromString("2020-01-01T15:00:00Z")
+						expectedDatum.TimeZoneName = pointer.FromString("America/Chicago")
+						expectedDatum.TimeZoneOffset = pointer.FromInt(-360)
+					},
+				),
+				Entry("DeviceTime unset",
+					func(datum *types.Base) {
+						datum.Time = pointer.FromString("2020-01-01T15:00:00Z")
+						datum.TimeZoneName = pointer.FromString("America/Chicago")
+						datum.TimeZoneOffset = pointer.FromInt(-360)
+						datum.DeviceTime = nil
+					},
+					func(datum *types.Base, expectedDatum *types.Base) {
+						expectedDatum.Time = pointer.FromString("2020-01-01T15:00:00Z")
+						expectedDatum.TimeZoneName = pointer.FromString("America/Chicago")
+						expectedDatum.TimeZoneOffset = pointer.FromInt(-360)
+						expectedDatum.DeviceTime = pointer.FromString("2020-01-01T09:00:00")
+					},
+				),
+				Entry("DeviceTime set with incorrect value",
+					func(datum *types.Base) {
+						datum.Time = pointer.FromString("2020-01-01T15:00:00Z")
+						datum.TimeZoneName = pointer.FromString("America/Chicago")
+						datum.TimeZoneOffset = pointer.FromInt(-360)
+						datum.DeviceTime = pointer.FromString("2014-10-15T22:00:00")
+					},
+					func(datum *types.Base, expectedDatum *types.Base) {
+						expectedDatum.Time = pointer.FromString("2020-01-01T15:00:00Z")
+						expectedDatum.TimeZoneName = pointer.FromString("America/Chicago")
+						expectedDatum.TimeZoneOffset = pointer.FromInt(-360)
+						expectedDatum.DeviceTime = pointer.FromString("2020-01-01T09:00:00")
+					},
+				),
 			)
 		})
 	})

--- a/data/types/test/base.go
+++ b/data/types/test/base.go
@@ -16,6 +16,12 @@ import (
 )
 
 func NewBase() *types.Base {
+
+	timeReference := test.RandomTime()
+	zoneName := timeZoneTest.RandomName()
+	zoneLoc, _ := time.LoadLocation(zoneName)
+	_, offset := timeReference.UTC().In(zoneLoc).Zone()
+
 	createdTime := test.RandomTimeFromRange(test.RandomTimeMinimum(), time.Now().Add(-30*24*time.Hour))
 	archivedTime := test.RandomTimeFromRange(createdTime, time.Now().Add(-7*24*time.Hour))
 	modifiedTime := test.RandomTimeFromRange(archivedTime, time.Now().Add(-24*time.Hour))
@@ -35,7 +41,7 @@ func NewBase() *types.Base {
 	datum.DeletedTime = pointer.FromString(deletedTime.Format(time.RFC3339Nano))
 	datum.DeletedUserID = pointer.FromString(userTest.RandomID())
 	datum.DeviceID = pointer.FromString(dataTest.NewDeviceID())
-	datum.DeviceTime = pointer.FromString(test.RandomTime().Format("2006-01-02T15:04:05"))
+	datum.DeviceTime = pointer.FromString(timeReference.In(zoneLoc).Format("2006-01-02T15:04:05"))
 	datum.GUID = pointer.FromString(dataTest.RandomID())
 	datum.ID = pointer.FromString(dataTest.RandomID())
 	datum.Location = locationTest.RandomLocation()
@@ -47,9 +53,9 @@ func NewBase() *types.Base {
 	datum.SchemaVersion = 2
 	datum.Source = pointer.FromString("carelink")
 	datum.Tags = pointer.FromStringArray([]string{NewTag(1, 10)})
-	datum.Time = pointer.FromString(test.RandomTime().Format(time.RFC3339Nano))
-	datum.TimeZoneName = pointer.FromString(timeZoneTest.RandomName())
-	datum.TimeZoneOffset = pointer.FromInt(NewTimeZoneOffset())
+	datum.Time = pointer.FromString(timeReference.Format(time.RFC3339Nano))
+	datum.TimeZoneName = pointer.FromString(zoneName)
+	datum.TimeZoneOffset = pointer.FromInt(offset / 60)
 	datum.Type = NewType()
 	datum.UploadID = pointer.FromString(dataTest.RandomSetID())
 	datum.UserID = pointer.FromString(userTest.RandomID())


### PR DESCRIPTION
- **Time** is formatted to UTC with RFC3339Nano format if an offset is set in the string for the following formats: 
    - "2006-01-02T15:04:05.999-0700"
    - "2006-01-02T15:04:05.999999999Z07:00" (time.RFC3339Nano in golang time package)

- **TimeZoneOffset** : 
    - if an offset is detected in the Time pattern, the field is set to the value detected (converted in minutes). 
    - if the field is not set and the TimeZoneName is set, the field is set to the value processed from Time and TimeZoneName.
    -  if the field is not set and the TimeZoneName is not set, the field is set to 0 (UTC offset).
 
- **TimeZoneName**: the field is set to nil if the TimeZoneOffset doesn’t match the TimeZoneName for the current Time
 
- **DeviceTime**: the field is always set from the Time field calculated with the TimeZoneOffset and formatted with the expected format i.e. : “2006-01-02T15:04:05“