### PR TITLE
PT-1295 Adding iob and prescriptor to bolus objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The Tidepool platform API
 - PT-1287 Integrate Tidepool master for platform
 - PT-1301 Add declaration time to wizard object
 - PT-1282 Update meal information
+- PT-1295 Store Additional fields for Bolus object
 
 ## 0.7.2 - 2020-05-14 
 ### Changed

--- a/data/types/bolus/bolus.go
+++ b/data/types/bolus/bolus.go
@@ -79,11 +79,14 @@ func (b *Bolus) Normalize(normalizer data.Normalizer) {
 	if b.InsulinFormulation != nil {
 		b.InsulinFormulation.Normalize(normalizer.WithReference("insulinFormulation"))
 	}
-	if b.InsulinOnBoard != nil {
-		b.InsulinOnBoard.Normalize(normalizer)
-	}
 	if b.Prescriptor != nil {
 		b.Prescriptor.Normalize(normalizer)
+	}
+	if b.InsulinOnBoard != nil {
+		b.InsulinOnBoard.Normalize(normalizer)
+		if b.Prescriptor != nil && *b.Prescriptor.Prescriptor == prescriptor.ManualPrescriptor {
+			b.InsulinOnBoard = nil
+		}
 	}
 }
 

--- a/data/types/bolus/bolus.go
+++ b/data/types/bolus/bolus.go
@@ -3,7 +3,7 @@ package bolus
 import (
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/types"
-	iob "github.com/tidepool-org/platform/data/types/bolus/iob"
+	"github.com/tidepool-org/platform/data/types/bolus/iob"
 	"github.com/tidepool-org/platform/data/types/bolus/prescriptor"
 	"github.com/tidepool-org/platform/data/types/insulin"
 	"github.com/tidepool-org/platform/errors"
@@ -83,9 +83,10 @@ func (b *Bolus) Normalize(normalizer data.Normalizer) {
 		b.Prescriptor.Normalize(normalizer)
 	}
 	if b.InsulinOnBoard != nil {
-		b.InsulinOnBoard.Normalize(normalizer)
 		if b.Prescriptor != nil && *b.Prescriptor.Prescriptor == prescriptor.ManualPrescriptor {
 			b.InsulinOnBoard = nil
+		} else {
+			b.InsulinOnBoard.Normalize(normalizer)
 		}
 	}
 }

--- a/data/types/bolus/bolus.go
+++ b/data/types/bolus/bolus.go
@@ -3,6 +3,8 @@ package bolus
 import (
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/types"
+	iob "github.com/tidepool-org/platform/data/types/bolus/iob"
+	"github.com/tidepool-org/platform/data/types/bolus/prescriptor"
 	"github.com/tidepool-org/platform/data/types/insulin"
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/structure"
@@ -17,7 +19,9 @@ type Bolus struct {
 
 	SubType string `json:"subType,omitempty" bson:"subType,omitempty"`
 
-	InsulinFormulation *insulin.Formulation `json:"insulinFormulation,omitempty" bson:"insulinFormulation,omitempty"`
+	InsulinFormulation *insulin.Formulation     `json:"insulinFormulation,omitempty" bson:"insulinFormulation,omitempty"`
+	Prescriptor        *prescriptor.Prescriptor `bson:",inline"`
+	InsulinOnBoard     *iob.Iob                 `bson:",inline"`
 }
 
 type Meta struct {
@@ -27,8 +31,10 @@ type Meta struct {
 
 func New(subType string) Bolus {
 	return Bolus{
-		Base:    types.New(Type),
-		SubType: subType,
+		Base:           types.New(Type),
+		SubType:        subType,
+		InsulinOnBoard: iob.NewIob(),
+		Prescriptor:    prescriptor.NewPrescriptor(),
 	}
 }
 
@@ -43,6 +49,8 @@ func (b *Bolus) Parse(parser structure.ObjectParser) {
 	b.Base.Parse(parser)
 
 	b.InsulinFormulation = insulin.ParseFormulation(parser.WithReferenceObjectParser("insulinFormulation"))
+	b.InsulinOnBoard.Parse(parser)
+	b.Prescriptor.Parse(parser)
 }
 
 func (b *Bolus) Validate(validator structure.Validator) {
@@ -57,6 +65,12 @@ func (b *Bolus) Validate(validator structure.Validator) {
 	if b.InsulinFormulation != nil {
 		b.InsulinFormulation.Validate(validator.WithReference("insulinFormulation"))
 	}
+	if b.InsulinOnBoard != nil {
+		b.InsulinOnBoard.Validate(validator)
+	}
+	if b.Prescriptor != nil {
+		b.Prescriptor.Validate(validator)
+	}
 }
 
 func (b *Bolus) Normalize(normalizer data.Normalizer) {
@@ -64,6 +78,12 @@ func (b *Bolus) Normalize(normalizer data.Normalizer) {
 
 	if b.InsulinFormulation != nil {
 		b.InsulinFormulation.Normalize(normalizer.WithReference("insulinFormulation"))
+	}
+	if b.InsulinOnBoard != nil {
+		b.InsulinOnBoard.Normalize(normalizer)
+	}
+	if b.Prescriptor != nil {
+		b.Prescriptor.Normalize(normalizer)
 	}
 }
 

--- a/data/types/bolus/bolus_test.go
+++ b/data/types/bolus/bolus_test.go
@@ -7,6 +7,7 @@ import (
 
 	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/types/bolus"
+	"github.com/tidepool-org/platform/data/types/bolus/prescriptor"
 	dataTypesBolusTest "github.com/tidepool-org/platform/data/types/bolus/test"
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
@@ -116,6 +117,9 @@ var _ = Describe("Bolus", func() {
 						datum := dataTypesBolusTest.NewBolus()
 						mutator(datum)
 						expectedDatum := dataTypesBolusTest.CloneBolus(datum)
+						if *datum.Prescriptor.Prescriptor == prescriptor.ManualPrescriptor {
+							expectedDatum.InsulinOnBoard = nil
+						}
 						normalizer := dataNormalizer.New()
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
@@ -135,6 +139,12 @@ var _ = Describe("Bolus", func() {
 				),
 				Entry("does not modify the datum; insulin formulation missing",
 					func(datum *bolus.Bolus) { datum.InsulinFormulation = nil },
+				),
+				Entry("does modify the datum; iob is ignored for manual prescriptor",
+					func(datum *bolus.Bolus) {
+						datum.Prescriptor.Prescriptor = pointer.FromString(prescriptor.ManualPrescriptor)
+						datum.InsulinOnBoard.InsulinOnBoard = pointer.FromFloat64(10)
+					},
 				),
 			)
 		})

--- a/data/types/bolus/combination/combination_test.go
+++ b/data/types/bolus/combination/combination_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/bolus"
 	"github.com/tidepool-org/platform/data/types/bolus/combination"
 	dataTypesBolusCombinationTest "github.com/tidepool-org/platform/data/types/bolus/combination/test"
+	"github.com/tidepool-org/platform/data/types/bolus/prescriptor"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/pointer"
@@ -1149,6 +1150,9 @@ var _ = Describe("Combination", func() {
 						datum := dataTypesBolusCombinationTest.NewCombination()
 						mutator(datum)
 						expectedDatum := dataTypesBolusCombinationTest.CloneCombination(datum)
+						if *datum.Prescriptor.Prescriptor == prescriptor.ManualPrescriptor {
+							expectedDatum.InsulinOnBoard = nil
+						}
 						normalizer := dataNormalizer.New()
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))

--- a/data/types/bolus/extended/extended_test.go
+++ b/data/types/bolus/extended/extended_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/bolus"
 	"github.com/tidepool-org/platform/data/types/bolus/extended"
 	dataTypesBolusExtendedTest "github.com/tidepool-org/platform/data/types/bolus/extended/test"
+	"github.com/tidepool-org/platform/data/types/bolus/prescriptor"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/pointer"
@@ -509,6 +510,9 @@ var _ = Describe("Extended", func() {
 						datum := dataTypesBolusExtendedTest.NewExtended()
 						mutator(datum)
 						expectedDatum := dataTypesBolusExtendedTest.CloneExtended(datum)
+						if *datum.Prescriptor.Prescriptor == prescriptor.ManualPrescriptor {
+							expectedDatum.InsulinOnBoard = nil
+						}
 						normalizer := dataNormalizer.New()
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))

--- a/data/types/bolus/iob/iob.go
+++ b/data/types/bolus/iob/iob.go
@@ -1,0 +1,39 @@
+package iob
+
+import (
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/structure"
+)
+
+const (
+	InsulinOnBoardMaximum = 250.0
+	InsulinOnBoardMinimum = 0.0
+)
+
+type Iob struct {
+	InsulinOnBoard *float64 `json:"insulinOnBoard,omitempty" bson:"insulinOnBoard,omitempty"`
+}
+
+func ParseIob(parser structure.ObjectParser) *Iob {
+	if !parser.Exists() {
+		return nil
+	}
+	datum := NewIob()
+	parser.Parse(datum)
+	return datum
+}
+
+func NewIob() *Iob {
+	return &Iob{}
+}
+
+func (i *Iob) Parse(parser structure.ObjectParser) {
+	i.InsulinOnBoard = parser.Float64("insulinOnBoard")
+}
+
+func (i *Iob) Validate(validator structure.Validator) {
+	validator.Float64("insulinOnBoard", i.InsulinOnBoard).InRange(InsulinOnBoardMinimum, InsulinOnBoardMaximum)
+}
+
+func (i *Iob) Normalize(normalizer data.Normalizer) {
+}

--- a/data/types/bolus/iob/iob_suite_test.go
+++ b/data/types/bolus/iob/iob_suite_test.go
@@ -1,0 +1,11 @@
+package iob_test
+
+import (
+	"testing"
+
+	"github.com/tidepool-org/platform/test"
+)
+
+func TestSuite(t *testing.T) {
+	test.Test(t)
+}

--- a/data/types/bolus/iob/iob_test.go
+++ b/data/types/bolus/iob/iob_test.go
@@ -7,28 +7,13 @@ import (
 
 	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/types/bolus/iob"
+	dataTypesBolusIobTest "github.com/tidepool-org/platform/data/types/bolus/iob/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
-	"github.com/tidepool-org/platform/test"
 )
-
-func NewIob() *iob.Iob {
-	datum := iob.NewIob()
-	datum.InsulinOnBoard = pointer.FromFloat64(test.RandomFloat64FromRange(iob.InsulinOnBoardMinimum, iob.InsulinOnBoardMaximum))
-	return datum
-}
-
-func CloneIob(datum *iob.Iob) *iob.Iob {
-	if datum == nil {
-		return nil
-	}
-	clone := iob.NewIob()
-	clone.InsulinOnBoard = pointer.CloneFloat64(datum.InsulinOnBoard)
-	return clone
-}
 
 var _ = Describe("Iob", func() {
 
@@ -54,7 +39,7 @@ var _ = Describe("Iob", func() {
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
 				func(mutator func(datum *iob.Iob), expectedErrors ...error) {
-					datum := NewIob()
+					datum := dataTypesBolusIobTest.NewIob()
 					mutator(datum)
 					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 				},
@@ -85,9 +70,9 @@ var _ = Describe("Iob", func() {
 			DescribeTable("normalizes the datum",
 				func(mutator func(datum *iob.Iob)) {
 					for _, origin := range structure.Origins() {
-						datum := NewIob()
+						datum := dataTypesBolusIobTest.NewIob()
 						mutator(datum)
-						expectedDatum := CloneIob(datum)
+						expectedDatum := dataTypesBolusIobTest.CloneIob(datum)
 						normalizer := dataNormalizer.New()
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))

--- a/data/types/bolus/iob/iob_test.go
+++ b/data/types/bolus/iob/iob_test.go
@@ -1,0 +1,105 @@
+package iob_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
+	"github.com/tidepool-org/platform/data/types/bolus/iob"
+	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
+	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/structure"
+	structureValidator "github.com/tidepool-org/platform/structure/validator"
+	"github.com/tidepool-org/platform/test"
+)
+
+func NewIob() *iob.Iob {
+	datum := iob.NewIob()
+	datum.InsulinOnBoard = pointer.FromFloat64(test.RandomFloat64FromRange(iob.InsulinOnBoardMinimum, iob.InsulinOnBoardMaximum))
+	return datum
+}
+
+func CloneIob(datum *iob.Iob) *iob.Iob {
+	if datum == nil {
+		return nil
+	}
+	clone := iob.NewIob()
+	clone.InsulinOnBoard = pointer.CloneFloat64(datum.InsulinOnBoard)
+	return clone
+}
+
+var _ = Describe("Iob", func() {
+
+	It("InsulinOnBoardMaximum is expected", func() {
+		Expect(iob.InsulinOnBoardMaximum).To(Equal(250.0))
+	})
+
+	It("InsulinOnBoardMinimum is expected", func() {
+		Expect(iob.InsulinOnBoardMinimum).To(Equal(0.0))
+	})
+
+	Context("NewIob", func() {
+		It("is successful", func() {
+			Expect(iob.NewIob()).To(Equal(&iob.Iob{}))
+		})
+	})
+
+	Context("Iob", func() {
+		Context("Parse", func() {
+			// TODO
+		})
+
+		Context("Validate", func() {
+			DescribeTable("validates the datum",
+				func(mutator func(datum *iob.Iob), expectedErrors ...error) {
+					datum := NewIob()
+					mutator(datum)
+					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
+				},
+				Entry("succeeds",
+					func(datum *iob.Iob) {},
+				),
+				Entry("Valid value",
+					func(datum *iob.Iob) {
+						datum.InsulinOnBoard = pointer.FromFloat64(10)
+					},
+				),
+				Entry("insulin on board out of range (lower)",
+					func(datum *iob.Iob) {
+						datum.InsulinOnBoard = pointer.FromFloat64(-0.1)
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 250.0), "/insulinOnBoard"),
+				),
+				Entry("insulin on board out of range (upper)",
+					func(datum *iob.Iob) {
+						datum.InsulinOnBoard = pointer.FromFloat64(250.1)
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(250.1, 0.0, 250.0), "/insulinOnBoard"),
+				),
+			)
+		})
+
+		Context("Normalize", func() {
+			DescribeTable("normalizes the datum",
+				func(mutator func(datum *iob.Iob)) {
+					for _, origin := range structure.Origins() {
+						datum := NewIob()
+						mutator(datum)
+						expectedDatum := CloneIob(datum)
+						normalizer := dataNormalizer.New()
+						Expect(normalizer).ToNot(BeNil())
+						datum.Normalize(normalizer.WithOrigin(origin))
+						Expect(normalizer.Error()).To(BeNil())
+						Expect(normalizer.Data()).To(BeEmpty())
+						Expect(datum).To(Equal(expectedDatum))
+					}
+				},
+				Entry("does not modify the datum",
+					func(datum *iob.Iob) {},
+				),
+			)
+		})
+	})
+})

--- a/data/types/bolus/iob/test/iob.go
+++ b/data/types/bolus/iob/test/iob.go
@@ -1,0 +1,22 @@
+package test
+
+import (
+	"github.com/tidepool-org/platform/data/types/bolus/iob"
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/test"
+)
+
+func NewIob() *iob.Iob {
+	datum := iob.NewIob()
+	datum.InsulinOnBoard = pointer.FromFloat64(test.RandomFloat64FromRange(iob.InsulinOnBoardMinimum, iob.InsulinOnBoardMaximum))
+	return datum
+}
+
+func CloneIob(datum *iob.Iob) *iob.Iob {
+	if datum == nil {
+		return nil
+	}
+	clone := iob.NewIob()
+	clone.InsulinOnBoard = pointer.CloneFloat64(datum.InsulinOnBoard)
+	return clone
+}

--- a/data/types/bolus/normal/normal_test.go
+++ b/data/types/bolus/normal/normal_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/bolus"
 	"github.com/tidepool-org/platform/data/types/bolus/normal"
 	dataTypesBolusNormalTest "github.com/tidepool-org/platform/data/types/bolus/normal/test"
+	"github.com/tidepool-org/platform/data/types/bolus/prescriptor"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/pointer"
@@ -282,6 +283,9 @@ var _ = Describe("Normal", func() {
 						datum := dataTypesBolusNormalTest.NewNormal()
 						mutator(datum)
 						expectedDatum := dataTypesBolusNormalTest.CloneNormal(datum)
+						if *datum.Prescriptor.Prescriptor == prescriptor.ManualPrescriptor {
+							expectedDatum.InsulinOnBoard = nil
+						}
 						normalizer := dataNormalizer.New()
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))

--- a/data/types/bolus/prescriptor/prescriptor.go
+++ b/data/types/bolus/prescriptor/prescriptor.go
@@ -1,0 +1,48 @@
+package prescriptor
+
+import (
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/structure"
+)
+
+const (
+	ManualPrescriptor = "manual"
+	AutoPrescriptor   = "auto"
+	HybridPrescriptor = "hybrid"
+)
+
+func Presciptors() []string {
+	return []string{
+		AutoPrescriptor,
+		ManualPrescriptor,
+		HybridPrescriptor,
+	}
+}
+
+type Prescriptor struct {
+	Prescriptor *string `json:"prescriptor,omitempty" bson:"prescriptor,omitempty"`
+}
+
+func ParsePrescriptor(parser structure.ObjectParser) *Prescriptor {
+	if !parser.Exists() {
+		return nil
+	}
+	datum := NewPrescriptor()
+	parser.Parse(datum)
+	return datum
+}
+
+func NewPrescriptor() *Prescriptor {
+	return &Prescriptor{}
+}
+
+func (p *Prescriptor) Parse(parser structure.ObjectParser) {
+	p.Prescriptor = parser.String("prescriptor")
+}
+
+func (p *Prescriptor) Validate(validator structure.Validator) {
+	validator.String("prescriptor", p.Prescriptor).OneOf(Presciptors()...)
+}
+
+func (p *Prescriptor) Normalize(normalizer data.Normalizer) {
+}

--- a/data/types/bolus/prescriptor/prescriptor_suite_test.go
+++ b/data/types/bolus/prescriptor/prescriptor_suite_test.go
@@ -1,0 +1,11 @@
+package prescriptor_test
+
+import (
+	"testing"
+
+	"github.com/tidepool-org/platform/test"
+)
+
+func TestSuite(t *testing.T) {
+	test.Test(t)
+}

--- a/data/types/bolus/prescriptor/prescriptor_test.go
+++ b/data/types/bolus/prescriptor/prescriptor_test.go
@@ -31,7 +31,7 @@ func ClonePrescriptor(datum *prescriptor.Prescriptor) *prescriptor.Prescriptor {
 }
 
 var _ = Describe("Prescriptor", func() {
-	Context("Addition of two digits", func() {
+	Context("Object Creation", func() {
 
 		It("Manual Prescriptor is expected", func() {
 			Expect(prescriptor.ManualPrescriptor).To(Equal("manual"))

--- a/data/types/bolus/prescriptor/prescriptor_test.go
+++ b/data/types/bolus/prescriptor/prescriptor_test.go
@@ -7,28 +7,13 @@ import (
 
 	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/types/bolus/prescriptor"
+	dataTypesBolusPrescriptorTest "github.com/tidepool-org/platform/data/types/bolus/prescriptor/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
-	"github.com/tidepool-org/platform/test"
 )
-
-func NewPrescriptor() *prescriptor.Prescriptor {
-	datum := prescriptor.NewPrescriptor()
-	datum.Prescriptor = pointer.FromString(test.RandomStringFromArray(prescriptor.Presciptors()))
-	return datum
-}
-
-func ClonePrescriptor(datum *prescriptor.Prescriptor) *prescriptor.Prescriptor {
-	if datum == nil {
-		return nil
-	}
-	clone := prescriptor.NewPrescriptor()
-	clone.Prescriptor = pointer.CloneString(datum.Prescriptor)
-	return clone
-}
 
 var _ = Describe("Prescriptor", func() {
 	Context("Object Creation", func() {
@@ -60,14 +45,14 @@ var _ = Describe("Prescriptor", func() {
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
 				func(mutator func(datum *prescriptor.Prescriptor), expectedErrors ...error) {
-					datum := NewPrescriptor()
+					datum := dataTypesBolusPrescriptorTest.NewPrescriptor()
 					mutator(datum)
 					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *prescriptor.Prescriptor) {},
 				),
-				Entry("Valid value",
+				Entry("Prescriptor is nil",
 					func(datum *prescriptor.Prescriptor) {
 						datum.Prescriptor = nil
 					},
@@ -85,9 +70,9 @@ var _ = Describe("Prescriptor", func() {
 			DescribeTable("normalizes the datum",
 				func(mutator func(datum *prescriptor.Prescriptor)) {
 					for _, origin := range structure.Origins() {
-						datum := NewPrescriptor()
+						datum := dataTypesBolusPrescriptorTest.NewPrescriptor()
 						mutator(datum)
-						expectedDatum := ClonePrescriptor(datum)
+						expectedDatum := dataTypesBolusPrescriptorTest.ClonePrescriptor(datum)
 						normalizer := dataNormalizer.New()
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))

--- a/data/types/bolus/prescriptor/prescriptor_test.go
+++ b/data/types/bolus/prescriptor/prescriptor_test.go
@@ -1,0 +1,105 @@
+package prescriptor_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
+	"github.com/tidepool-org/platform/data/types/bolus/prescriptor"
+	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
+	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/structure"
+	structureValidator "github.com/tidepool-org/platform/structure/validator"
+	"github.com/tidepool-org/platform/test"
+)
+
+func NewPrescriptor() *prescriptor.Prescriptor {
+	datum := prescriptor.NewPrescriptor()
+	datum.Prescriptor = pointer.FromString(test.RandomStringFromArray(prescriptor.Presciptors()))
+	return datum
+}
+
+func ClonePrescriptor(datum *prescriptor.Prescriptor) *prescriptor.Prescriptor {
+	if datum == nil {
+		return nil
+	}
+	clone := prescriptor.NewPrescriptor()
+	clone.Prescriptor = pointer.CloneString(datum.Prescriptor)
+	return clone
+}
+
+var _ = Describe("Prescriptor", func() {
+	Context("Addition of two digits", func() {
+
+		It("Manual Prescriptor is expected", func() {
+			Expect(prescriptor.ManualPrescriptor).To(Equal("manual"))
+		})
+
+		It("Auto Prescriptor is expected", func() {
+			Expect(prescriptor.AutoPrescriptor).To(Equal("auto"))
+		})
+
+		It("Hybrid Prescriptor is expected", func() {
+			Expect(prescriptor.HybridPrescriptor).To(Equal("hybrid"))
+		})
+
+		Context("NewPrescriptor", func() {
+			It("is successful", func() {
+				Expect(prescriptor.NewPrescriptor()).To(Equal(&prescriptor.Prescriptor{}))
+			})
+		})
+
+	})
+	Context("Prescriptor", func() {
+		Context("Parse", func() {
+			// TODO
+		})
+
+		Context("Validate", func() {
+			DescribeTable("validates the datum",
+				func(mutator func(datum *prescriptor.Prescriptor), expectedErrors ...error) {
+					datum := NewPrescriptor()
+					mutator(datum)
+					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
+				},
+				Entry("succeeds",
+					func(datum *prescriptor.Prescriptor) {},
+				),
+				Entry("Valid value",
+					func(datum *prescriptor.Prescriptor) {
+						datum.Prescriptor = nil
+					},
+				),
+				Entry("Invalid Prescriptor value",
+					func(datum *prescriptor.Prescriptor) {
+						datum.Prescriptor = pointer.FromString("invalid")
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"auto", "manual", "hybrid"}), "/prescriptor"),
+				),
+			)
+		})
+
+		Context("Normalize", func() {
+			DescribeTable("normalizes the datum",
+				func(mutator func(datum *prescriptor.Prescriptor)) {
+					for _, origin := range structure.Origins() {
+						datum := NewPrescriptor()
+						mutator(datum)
+						expectedDatum := ClonePrescriptor(datum)
+						normalizer := dataNormalizer.New()
+						Expect(normalizer).ToNot(BeNil())
+						datum.Normalize(normalizer.WithOrigin(origin))
+						Expect(normalizer.Error()).To(BeNil())
+						Expect(normalizer.Data()).To(BeEmpty())
+						Expect(datum).To(Equal(expectedDatum))
+					}
+				},
+				Entry("does not modify the datum",
+					func(datum *prescriptor.Prescriptor) {},
+				),
+			)
+		})
+	})
+})

--- a/data/types/bolus/prescriptor/test/prescriptor.go
+++ b/data/types/bolus/prescriptor/test/prescriptor.go
@@ -1,0 +1,22 @@
+package test
+
+import (
+	"github.com/tidepool-org/platform/data/types/bolus/prescriptor"
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/test"
+)
+
+func NewPrescriptor() *prescriptor.Prescriptor {
+	datum := prescriptor.NewPrescriptor()
+	datum.Prescriptor = pointer.FromString(test.RandomStringFromArray(prescriptor.Presciptors()))
+	return datum
+}
+
+func ClonePrescriptor(datum *prescriptor.Prescriptor) *prescriptor.Prescriptor {
+	if datum == nil {
+		return nil
+	}
+	clone := prescriptor.NewPrescriptor()
+	clone.Prescriptor = pointer.FromString(*datum.Prescriptor)
+	return clone
+}

--- a/data/types/bolus/prescriptor/test/prescriptor.go
+++ b/data/types/bolus/prescriptor/test/prescriptor.go
@@ -17,6 +17,6 @@ func ClonePrescriptor(datum *prescriptor.Prescriptor) *prescriptor.Prescriptor {
 		return nil
 	}
 	clone := prescriptor.NewPrescriptor()
-	clone.Prescriptor = pointer.FromString(*datum.Prescriptor)
+	clone.Prescriptor = pointer.CloneString(datum.Prescriptor)
 	return clone
 }

--- a/data/types/bolus/test/bolus.go
+++ b/data/types/bolus/test/bolus.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	"github.com/tidepool-org/platform/data/types/bolus"
+	dataTypeIobTest "github.com/tidepool-org/platform/data/types/bolus/iob/test"
+	dataTypePrescriptorTest "github.com/tidepool-org/platform/data/types/bolus/prescriptor/test"
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 )
@@ -12,6 +14,8 @@ func NewBolus() *bolus.Bolus {
 	datum.Type = "bolus"
 	datum.SubType = dataTypesTest.NewType()
 	datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3)
+	datum.InsulinOnBoard = dataTypeIobTest.NewIob()
+	datum.Prescriptor = dataTypePrescriptorTest.NewPrescriptor()
 	return datum
 }
 
@@ -23,5 +27,7 @@ func CloneBolus(datum *bolus.Bolus) *bolus.Bolus {
 	clone.Base = *dataTypesTest.CloneBase(&datum.Base)
 	clone.SubType = datum.SubType
 	clone.InsulinFormulation = dataTypesInsulinTest.CloneFormulation(datum.InsulinFormulation)
+	clone.InsulinOnBoard = dataTypeIobTest.CloneIob(datum.InsulinOnBoard)
+	clone.Prescriptor = dataTypePrescriptorTest.ClonePrescriptor(datum.Prescriptor)
 	return clone
 }


### PR DESCRIPTION
- iob and prescriptor are created as types that can be leveraged in other objects
- those 2 objects are then added into the main Bolus object 