### PR TITLE
PT-1392 Fix food prescriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Platform 
 The Tidepool platform API
 
-## 0.8.1 - 2020-06-26
+## 0.8.1 - 2020-07-02
 ### Fixed
-- PT-XXXX make data service backward compatible for food object that does contain prescriptor. 
+- PT-1392 make data service backward compatible for food object that does contain prescriptor. 
 
 ## 0.8.0 - 2020-06-25
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Platform 
 The Tidepool platform API
 
+## 0.8.1 - 2020-06-26
+### Fixed
+- PT-XXXX make data service backward compatible for food object that does contain prescriptor. 
+
 ## 0.8.0 - 2020-06-25
 ### Changed
 - PT-1287 Integrate Tidepool master for platform

--- a/data/types/food/food.go
+++ b/data/types/food/food.go
@@ -105,7 +105,7 @@ func (f *Food) Validate(validator structure.Validator) {
 		f.Nutrition.Validate(validator.WithReference("nutrition"))
 	}
 	if f.Meal != nil && *f.Meal == MealRescueCarbs {
-		if f.Prescriptor != nil {
+		if f.Prescriptor != nil && f.Prescriptor.Prescriptor != nil {
 			f.Prescriptor.Validate(validator)
 			if *f.Prescriptor.Prescriptor == common.HybridPrescriptor && f.PrescribedNutrition == nil {
 				// Prescribed Nutrition is mandatory
@@ -145,7 +145,7 @@ func (f *Food) Normalize(normalizer data.Normalizer) {
 	if f.Nutrition != nil {
 		f.Nutrition.Normalize(normalizer.WithReference("nutrition"))
 	}
-	if f.Prescriptor != nil && *f.Prescriptor.Prescriptor == common.HybridPrescriptor && f.PrescribedNutrition != nil {
+	if f.Prescriptor != nil && f.Prescriptor.Prescriptor != nil && *f.Prescriptor.Prescriptor == common.HybridPrescriptor && f.PrescribedNutrition != nil {
 		f.PrescribedNutrition.Normalize(normalizer.WithReference("nutrition"))
 	} else {
 		f.PrescribedNutrition = nil

--- a/data/types/food/food_test.go
+++ b/data/types/food/food_test.go
@@ -510,7 +510,7 @@ var _ = Describe("Food", func() {
 				),
 			)
 
-			DescribeTable("normalizes the datum for rescueCarbs and any other prescriptor; PrescribedNutrition is changed to nil ",
+			DescribeTable("normalizes the datum for rescueCarbs and any other prescriptor; PrescribedNutrition is changed to nil",
 				func(mutator func(datum *food.Food)) {
 					for _, origin := range structure.Origins() {
 						datum := NewFood(3)

--- a/data/types/food/food_test.go
+++ b/data/types/food/food_test.go
@@ -413,10 +413,13 @@ var _ = Describe("Food", func() {
 				func(mutator func(datum *food.Food)) {
 					for _, origin := range structure.Origins() {
 						datum := NewFood(3)
+						datum.Meal = pointer.FromString(test.RandomStringFromArray([]string{food.MealBreakfast, food.MealDinner, food.MealLunch, food.MealOther, food.MealSnack}))
 						datum.Prescriptor = nil
 						datum.PrescribedNutrition = nil
 						mutator(datum)
 						expectedDatum := CloneFood(datum)
+						expectedDatum.Prescriptor = nil
+						expectedDatum.PrescribedNutrition = nil
 						normalizer := dataNormalizer.New()
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
@@ -451,6 +454,11 @@ var _ = Describe("Food", func() {
 				),
 				Entry("does not modify the datum; nutrition missing",
 					func(datum *food.Food) { datum.Nutrition = nil },
+				),
+				Entry("does not crash when prescriptor is not set",
+					func(datum *food.Food) {
+						datum.Prescriptor = common.NewPrescriptor()
+					},
 				),
 			)
 
@@ -497,9 +505,12 @@ var _ = Describe("Food", func() {
 				Entry("does not modify the datum; nutrition missing",
 					func(datum *food.Food) { datum.Nutrition = nil },
 				),
+				Entry("does not modify the datum; prescribedNutrition missing",
+					func(datum *food.Food) { datum.PrescribedNutrition = nil },
+				),
 			)
 
-			DescribeTable("normalizes the datum for rescueCarbs, other prescriptor",
+			DescribeTable("normalizes the datum for rescueCarbs and any other prescriptor; PrescribedNutrition is changed to nil ",
 				func(mutator func(datum *food.Food)) {
 					for _, origin := range structure.Origins() {
 						datum := NewFood(3)
@@ -542,6 +553,11 @@ var _ = Describe("Food", func() {
 				),
 				Entry("does not modify the datum; nutrition missing",
 					func(datum *food.Food) { datum.Nutrition = nil },
+				),
+				Entry("modify the datum; prescribedNutrition is reset to nil",
+					func(datum *food.Food) {
+						datum.PrescribedNutrition = NewNutrition()
+					},
 				),
 			)
 

--- a/data/types/food/food_test.go
+++ b/data/types/food/food_test.go
@@ -355,7 +355,7 @@ var _ = Describe("Food", func() {
 					func(datum *food.Food) {
 						datum.Meal = pointer.FromString("rescuecarbs")
 						datum.MealOther = nil
-						datum.Prescriptor = nil
+						datum.Prescriptor = common.NewPrescriptor()
 						datum.PrescribedNutrition = NewNutrition()
 					},
 				),

--- a/data/types/food/food_test.go
+++ b/data/types/food/food_test.go
@@ -566,7 +566,7 @@ var _ = Describe("Food", func() {
 				),
 				Entry("does not crash when prescriptor is not set",
 					func(datum *food.Food) {
-						datum.Prescriptor = common.NewPrescriptor()
+						datum.Prescriptor.Prescriptor = nil
 					},
 				),
 			)

--- a/data/types/food/food_test.go
+++ b/data/types/food/food_test.go
@@ -455,9 +455,14 @@ var _ = Describe("Food", func() {
 				Entry("does not modify the datum; nutrition missing",
 					func(datum *food.Food) { datum.Nutrition = nil },
 				),
-				Entry("does not crash when prescriptor is not set",
+				Entry("does not crash when prescriptor is set",
 					func(datum *food.Food) {
-						datum.Prescriptor = common.NewPrescriptor()
+						datum.Prescriptor = dataTypesCommonTest.NewPrescriptor()
+					},
+				),
+				Entry("does not crash when prescribedNutrition is set",
+					func(datum *food.Food) {
+						datum.PrescribedNutrition = NewNutrition()
 					},
 				),
 			)
@@ -557,6 +562,11 @@ var _ = Describe("Food", func() {
 				Entry("modify the datum; prescribedNutrition is reset to nil",
 					func(datum *food.Food) {
 						datum.PrescribedNutrition = NewNutrition()
+					},
+				),
+				Entry("does not crash when prescriptor is not set",
+					func(datum *food.Food) {
+						datum.Prescriptor = common.NewPrescriptor()
 					},
 				),
 			)


### PR DESCRIPTION
Fix backward compatibility when prescriptor was not present in the food object for a rescuecarbs meal 