### PR TITLE
PT-1435 Platform services should be able to start without MongoDb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The Tidepool platform API
 ## 0.10.0 2020-09-09
 ### Changed 
-- PT-1435 latform services should be able to start without MongoDb
+- PT-1435 Platform services should be able to start without MongoDb
 
 ## 0.9.1 2020-08-18
 ### Fixed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Platform 
 The Tidepool platform API
-## Unreleased
+## 0.10.0 2020-09-09
 ### Changed 
 - PT-1435 latform services should be able to start without MongoDb
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Platform 
 The Tidepool platform API
+## Unreleased
+### Changed 
+- PT-1435 latform services should be able to start without MongoDb
 
 ## 0.9.1 2020-08-18
 ### Fixed 

--- a/auth/service/service/service.go
+++ b/auth/service/service/service.go
@@ -165,13 +165,6 @@ func (s *Service) initializeAuthStore() error {
 	}
 	s.authStore = str
 
-	s.Logger().Debug("Ensuring auth store indexes")
-
-	err = s.authStore.EnsureIndexes()
-	if err != nil {
-		return errors.Wrap(err, "unable to ensure auth store indexes")
-	}
-
 	return nil
 }
 

--- a/auth/store/mongo/provider_session_session.go
+++ b/auth/store/mongo/provider_session_session.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	mgo "github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 
 	"github.com/tidepool-org/platform/auth"
@@ -17,14 +16,6 @@ import (
 
 type ProviderSessionSession struct {
 	*storeStructuredMongo.Session
-}
-
-func (p *ProviderSessionSession) EnsureIndexes() error {
-	return p.EnsureAllIndexes([]mgo.Index{
-		{Key: []string{"id"}, Unique: true, Background: true},
-		{Key: []string{"userId"}, Background: true},
-		{Key: []string{"userId", "type", "name"}, Unique: true, Background: true},
-	})
 }
 
 func (p *ProviderSessionSession) ListUserProviderSessions(ctx context.Context, userID string, filter *auth.ProviderSessionFilter, pagination *page.Pagination) (auth.ProviderSessions, error) {

--- a/auth/store/mongo/restricted_token_session.go
+++ b/auth/store/mongo/restricted_token_session.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	mgo "github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 
 	"github.com/tidepool-org/platform/auth"
@@ -17,13 +16,6 @@ import (
 
 type RestrictedTokenSession struct {
 	*storeStructuredMongo.Session
-}
-
-func (r *RestrictedTokenSession) EnsureIndexes() error {
-	return r.EnsureAllIndexes([]mgo.Index{
-		{Key: []string{"id"}, Unique: true, Background: true},
-		{Key: []string{"userId"}, Background: true},
-	})
 }
 
 func (r *RestrictedTokenSession) ListUserRestrictedTokens(ctx context.Context, userID string, filter *auth.RestrictedTokenFilter, pagination *page.Pagination) (auth.RestrictedTokens, error) {

--- a/auth/store/mongo/store_test.go
+++ b/auth/store/mongo/store_test.go
@@ -49,8 +49,6 @@ var _ = Describe("Store", func() {
 			Expect(str).ToNot(BeNil())
 		})
 
-		// TODO: EnsureIndexes
-
 		Context("NewProviderSessionSession", func() {
 			var ssn store.ProviderSessionSession
 

--- a/blob/service/service.go
+++ b/blob/service/service.go
@@ -93,13 +93,6 @@ func (s *Service) initializeBlobStructuredStore() error {
 	}
 	s.blobStructuredStore = blobStructuredStore
 
-	s.Logger().Debug("Ensuring blob structured store indexes")
-
-	err = s.blobStructuredStore.EnsureIndexes()
-	if err != nil {
-		return errors.Wrap(err, "unable to ensure blob structured store indexes")
-	}
-
 	return nil
 }
 

--- a/blob/store/structured/mongo/mongo_test.go
+++ b/blob/store/structured/mongo/mongo_test.go
@@ -116,6 +116,7 @@ var _ = Describe("Mongo", func() {
 		BeforeEach(func() {
 			var err error
 			store, err = blobStoreStructuredMongo.NewStore(config, logger)
+			store.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(store).ToNot(BeNil())
 			mgoSession = storeStructuredMongoTest.Session().Copy()
@@ -126,21 +127,6 @@ var _ = Describe("Mongo", func() {
 			if mgoSession != nil {
 				mgoSession.Close()
 			}
-		})
-
-		Context("EnsureIndexes", func() {
-			It("returns successfully", func() {
-				Expect(store.EnsureIndexes()).To(Succeed())
-				indexes, err := mgoCollection.Indexes()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(indexes).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("_id")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("id"), "Background": Equal(true), "Unique": Equal(true)}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("userId"), "Background": Equal(true)}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("mediaType"), "Background": Equal(true)}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("status"), "Background": Equal(true)}),
-				))
-			})
 		})
 
 		Context("NewSession", func() {
@@ -154,7 +140,6 @@ var _ = Describe("Mongo", func() {
 			var ctx context.Context
 
 			BeforeEach(func() {
-				Expect(store.EnsureIndexes()).To(Succeed())
 				session = store.NewSession()
 				ctx = log.NewContextWithLogger(context.Background(), logger)
 			})

--- a/confirmation/store/mongo/store.go
+++ b/confirmation/store/mongo/store.go
@@ -17,6 +17,17 @@ type Store struct {
 	*storeStructuredMongo.Store
 }
 
+var (
+	confirmationIndexes = map[string][]mgo.Index{
+		"confirmations": {
+			{Key: []string{"email"}, Background: true},
+			{Key: []string{"status"}, Background: true},
+			{Key: []string{"type"}, Background: true},
+			{Key: []string{"userId"}, Background: true},
+		},
+	}
+)
+
 func NewStore(cfg *storeStructuredMongo.Config, lgr log.Logger) (*Store, error) {
 	str, err := storeStructuredMongo.NewStore(cfg, lgr)
 	if err != nil {
@@ -26,12 +37,6 @@ func NewStore(cfg *storeStructuredMongo.Config, lgr log.Logger) (*Store, error) 
 	return &Store{
 		Store: str,
 	}, nil
-}
-
-func (s *Store) EnsureIndexes() error {
-	ssn := s.confirmationSession()
-	defer ssn.Close()
-	return ssn.EnsureIndexes()
 }
 
 func (s *Store) NewConfirmationSession() store.ConfirmationSession {
@@ -46,15 +51,6 @@ func (s *Store) confirmationSession() *ConfirmationSession {
 
 type ConfirmationSession struct {
 	*storeStructuredMongo.Session
-}
-
-func (c *ConfirmationSession) EnsureIndexes() error {
-	return c.EnsureAllIndexes([]mgo.Index{
-		{Key: []string{"email"}, Background: true},
-		{Key: []string{"status"}, Background: true},
-		{Key: []string{"type"}, Background: true},
-		{Key: []string{"userId"}, Background: true},
-	})
 }
 
 func (c *ConfirmationSession) DeleteUserConfirmations(ctx context.Context, userID string) error {

--- a/confirmation/store/mongo/store_test.go
+++ b/confirmation/store/mongo/store_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/globalsign/mgo/bson"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 
 	"github.com/tidepool-org/platform/confirmation/store"
 	"github.com/tidepool-org/platform/confirmation/store/mongo"
@@ -99,6 +98,7 @@ var _ = Describe("Store", func() {
 		BeforeEach(func() {
 			var err error
 			str, err = mongo.NewStore(cfg, logNull.NewLogger())
+			str.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(str).ToNot(BeNil())
 			mgoSession = storeStructuredMongoTest.Session().Copy()
@@ -109,21 +109,6 @@ var _ = Describe("Store", func() {
 			if mgoSession != nil {
 				mgoSession.Close()
 			}
-		})
-
-		Context("EnsureIndexes", func() {
-			It("returns successfully", func() {
-				Expect(str.EnsureIndexes()).To(Succeed())
-				indexes, err := mgoCollection.Indexes()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(indexes).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("_id")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("email")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("status")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("type")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("userId")}),
-				))
-			})
 		})
 
 		Context("NewConfirmationSession", func() {

--- a/data/service/service/standard.go
+++ b/data/service/service/standard.go
@@ -192,13 +192,6 @@ func (s *Standard) initializeDataStoreDEPRECATED() error {
 	}
 	s.dataStoreDEPRECATED = str
 
-	s.Logger().Debug("Ensuring data store DEPRECATED indexes")
-
-	err = s.dataStoreDEPRECATED.EnsureIndexes()
-	if err != nil {
-		return errors.Wrap(err, "unable to ensure data store DEPRECATED indexes")
-	}
-
 	return nil
 }
 
@@ -217,13 +210,6 @@ func (s *Standard) initializeDataSourceStructuredStore() error {
 		return errors.Wrap(err, "unable to create data source structured store")
 	}
 	s.dataSourceStructuredStore = str
-
-	s.Logger().Debug("Ensuring data source structured store indexes")
-
-	err = s.dataSourceStructuredStore.EnsureIndexes()
-	if err != nil {
-		return errors.Wrap(err, "unable to ensure data source structured store indexes")
-	}
 
 	return nil
 }

--- a/data/source/store/structured/mongo/mongo_test.go
+++ b/data/source/store/structured/mongo/mongo_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Mongo", func() {
 		It("returns a new store and no error when successful", func() {
 			var err error
 			store, err = dataSourceStoreStructuredMongo.NewStore(config, logger)
+			store.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(store).ToNot(BeNil())
 		})
@@ -115,6 +116,7 @@ var _ = Describe("Mongo", func() {
 		BeforeEach(func() {
 			var err error
 			store, err = dataSourceStoreStructuredMongo.NewStore(config, logger)
+			store.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(store).ToNot(BeNil())
 			mgoSession = storeStructuredMongoTest.Session().Copy()
@@ -125,19 +127,6 @@ var _ = Describe("Mongo", func() {
 			if mgoSession != nil {
 				mgoSession.Close()
 			}
-		})
-
-		Context("EnsureIndexes", func() {
-			It("returns successfully", func() {
-				Expect(store.EnsureIndexes()).To(Succeed())
-				indexes, err := mgoCollection.Indexes()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(indexes).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("_id")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("id"), "Background": Equal(true), "Unique": Equal(true)}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("userId"), "Background": Equal(true)}),
-				))
-			})
 		})
 
 		Context("NewSession", func() {
@@ -151,7 +140,6 @@ var _ = Describe("Mongo", func() {
 			var ctx context.Context
 
 			BeforeEach(func() {
-				Expect(store.EnsureIndexes()).To(Succeed())
 				session = store.NewSession()
 				ctx = log.NewContextWithLogger(context.Background(), logger)
 			})

--- a/data/storeDEPRECATED/mongo/mongo_test.go
+++ b/data/storeDEPRECATED/mongo/mongo_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/globalsign/mgo/bson"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/storeDEPRECATED"
@@ -150,6 +149,7 @@ var _ = Describe("Mongo", func() {
 		It("returns a new store and no error if successful", func() {
 			var err error
 			store, err = mongo.NewStore(config, logger)
+			store.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(store).ToNot(BeNil())
 		})
@@ -162,6 +162,7 @@ var _ = Describe("Mongo", func() {
 		BeforeEach(func() {
 			var err error
 			store, err = mongo.NewStore(config, logger)
+			store.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(store).ToNot(BeNil())
 			mgoSession = storeStructuredMongoTest.Session().Copy()
@@ -172,22 +173,6 @@ var _ = Describe("Mongo", func() {
 			if mgoSession != nil {
 				mgoSession.Close()
 			}
-		})
-
-		Context("EnsureIndexes", func() {
-			It("returns successfully", func() {
-				Expect(store.EnsureIndexes()).To(Succeed())
-				indexes, err := mgoCollection.Indexes()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(indexes).Should(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("_id")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("_userId", "_active", "_schemaVersion", "-time"), "Background": Equal(true), "Name": Equal("UserIdTypeWeighted")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("origin.id", "type", "-deletedTime", "_active"), "Background": Equal(true), "Name": Equal("OriginId")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("type", "uploadId"), "Background": Equal(true), "Name": Equal("typeUploadId")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("uploadId", "type", "-deletedTime", "_active"), "Background": Equal(true), "Name": Equal("UploadId")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("uploadId"), "Background": Equal(true), "Unique": Equal(true), "Name": Equal("UniqueUploadId"), "PartialFilter": HaveKeyWithValue("type", "upload")}),
-				))
-			})
 		})
 
 		Context("NewDataSession", func() {

--- a/data/storeDEPRECATED/store.go
+++ b/data/storeDEPRECATED/store.go
@@ -19,8 +19,6 @@ type Store interface {
 type DataSession interface {
 	io.Closer
 
-	EnsureIndexes() error
-
 	GetDataSetsForUserByID(ctx context.Context, userID string, filter *Filter, pagination *page.Pagination) ([]*upload.Upload, error)
 	GetDataSetByID(ctx context.Context, dataSetID string) (*upload.Upload, error)
 	CreateDataSet(ctx context.Context, dataSet *upload.Upload) error

--- a/data/storeDEPRECATED/test/data_session.go
+++ b/data/storeDEPRECATED/test/data_session.go
@@ -195,11 +195,6 @@ func NewDataSession() *DataSession {
 	}
 }
 
-// EnsureIndexes required in order to implement the DataSession interface
-func (d *DataSession) EnsureIndexes() error {
-	return nil
-}
-
 func (d *DataSession) GetDataSetsForUserByID(ctx context.Context, userID string, filter *dataStoreDEPRECATED.Filter, pagination *page.Pagination) ([]*upload.Upload, error) {
 	d.GetDataSetsForUserByIDInvocations++
 

--- a/image/service/service.go
+++ b/image/service/service.go
@@ -113,13 +113,6 @@ func (s *Service) initializeImageStructuredStore() error {
 	}
 	s.imageStructuredStore = imageStructuredStore
 
-	s.Logger().Debug("Ensuring image structured store indexes")
-
-	err = s.imageStructuredStore.EnsureIndexes()
-	if err != nil {
-		return errors.Wrap(err, "unable to ensure image structured store indexes")
-	}
-
 	return nil
 }
 

--- a/image/store/structured/mongo/mongo_test.go
+++ b/image/store/structured/mongo/mongo_test.go
@@ -108,6 +108,7 @@ var _ = Describe("Mongo", func() {
 		It("returns a new store and no error when successful", func() {
 			var err error
 			store, err = imageStoreStructuredMongo.NewStore(config, logger)
+			store.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(store).ToNot(BeNil())
 		})
@@ -120,6 +121,7 @@ var _ = Describe("Mongo", func() {
 		BeforeEach(func() {
 			var err error
 			store, err = imageStoreStructuredMongo.NewStore(config, logger)
+			store.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(store).ToNot(BeNil())
 			mgoSession = storeStructuredMongoTest.Session().Copy()
@@ -130,19 +132,6 @@ var _ = Describe("Mongo", func() {
 			if mgoSession != nil {
 				mgoSession.Close()
 			}
-		})
-
-		Context("EnsureIndexes", func() {
-			It("returns successfully", func() {
-				Expect(store.EnsureIndexes()).To(Succeed())
-				indexes, err := mgoCollection.Indexes()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(indexes).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("_id")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("id"), "Background": Equal(true), "Unique": Equal(true)}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("userId", "status"), "Background": Equal(true)}),
-				))
-			})
 		})
 
 		Context("NewSession", func() {
@@ -156,7 +145,6 @@ var _ = Describe("Mongo", func() {
 			var ctx context.Context
 
 			BeforeEach(func() {
-				Expect(store.EnsureIndexes()).To(Succeed())
 				session = store.NewSession()
 				ctx = log.NewContextWithLogger(context.Background(), logger)
 			})

--- a/message/store/mongo/mongo_test.go
+++ b/message/store/mongo/mongo_test.go
@@ -99,6 +99,7 @@ var _ = Describe("Mongo", func() {
 		It("returns a new store and no error if successful", func() {
 			var err error
 			mongoStore, err = messageStoreMongo.NewStore(mongoConfig, logTest.NewLogger())
+			mongoStore.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mongoStore).ToNot(BeNil())
 		})
@@ -108,6 +109,7 @@ var _ = Describe("Mongo", func() {
 		BeforeEach(func() {
 			var err error
 			mongoStore, err = messageStoreMongo.NewStore(mongoConfig, logTest.NewLogger())
+			mongoStore.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mongoStore).ToNot(BeNil())
 		})

--- a/permission/store/mongo/config_test.go
+++ b/permission/store/mongo/config_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Config", func() {
 		Context("with valid values", func() {
 			BeforeEach(func() {
 				config.Config = storeStructuredMongo.NewConfig()
-				config.Addresses = []string{"1.2.3.4", "5.6.7.8"}
+				config.SetAddresses([]string{"1.2.3.4", "5.6.7.8"})
 				config.TLS = false
 				config.Database = "database"
 				config.CollectionPrefix = "collection_prefix"
@@ -87,7 +87,7 @@ var _ = Describe("Config", func() {
 				})
 
 				It("returns an error if the base config is not valid", func() {
-					config.Addresses = nil
+					config.SetAddresses(nil)
 					Expect(config.Validate()).To(MatchError("addresses is missing"))
 				})
 

--- a/permission/store/mongo/mongo_test.go
+++ b/permission/store/mongo/mongo_test.go
@@ -107,6 +107,7 @@ var _ = Describe("Mongo", func() {
 		It("returns a new store and no error if successful", func() {
 			var err error
 			mongoStore, err = permissionStoreMongo.NewStore(mongoConfig, logTest.NewLogger())
+			mongoStore.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mongoStore).ToNot(BeNil())
 		})
@@ -116,6 +117,7 @@ var _ = Describe("Mongo", func() {
 		BeforeEach(func() {
 			var err error
 			mongoStore, err = permissionStoreMongo.NewStore(mongoConfig, logTest.NewLogger())
+			mongoStore.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mongoStore).ToNot(BeNil())
 		})

--- a/permission/store/mongo/mongo_test.go
+++ b/permission/store/mongo/mongo_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Mongo", func() {
 
 		It("returns an error if base config is invalid", func() {
 			var err error
-			mongoConfig.Config.Addresses = nil
+			mongoConfig.Config.SetAddresses(nil)
 			mongoStore, err = permissionStoreMongo.NewStore(mongoConfig, logTest.NewLogger())
 			Expect(err).To(MatchError("config is invalid; addresses is missing"))
 			Expect(mongoStore).To(BeNil())

--- a/profile/store/structured/mongo/mongo.go
+++ b/profile/store/structured/mongo/mongo.go
@@ -207,6 +207,6 @@ func (s *Session) get(logger log.Logger, userID string, condition *request.Condi
 			}
 		}
 	}
-
+	logger.Debug("Get")
 	return result, nil
 }

--- a/profile/store/structured/mongo/mongo_test.go
+++ b/profile/store/structured/mongo/mongo_test.go
@@ -70,6 +70,7 @@ var _ = Describe("Mongo", func() {
 		It("returns a new store and no error when successful", func() {
 			var err error
 			store, err = profileStoreStructuredMongo.NewStore(config, logger)
+			store.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(store).ToNot(BeNil())
 		})
@@ -82,6 +83,7 @@ var _ = Describe("Mongo", func() {
 		BeforeEach(func() {
 			var err error
 			store, err = profileStoreStructuredMongo.NewStore(config, logger)
+			store.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(store).ToNot(BeNil())
 			mgoSession = storeStructuredMongoTest.Session().Copy()

--- a/session/store/mongo/mongo_test.go
+++ b/session/store/mongo/mongo_test.go
@@ -93,6 +93,7 @@ var _ = Describe("Mongo", func() {
 		It("returns a new store and no error if successful", func() {
 			var err error
 			mongoStore, err = sessionStoreMongo.NewStore(mongoConfig, logTest.NewLogger())
+			mongoStore.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mongoStore).ToNot(BeNil())
 		})
@@ -102,6 +103,7 @@ var _ = Describe("Mongo", func() {
 		BeforeEach(func() {
 			var err error
 			mongoStore, err = sessionStoreMongo.NewStore(mongoConfig, logTest.NewLogger())
+			mongoStore.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mongoStore).ToNot(BeNil())
 		})

--- a/store/structured/mongo/config.go
+++ b/store/structured/mongo/config.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	mgo "github.com/globalsign/mgo"
@@ -15,8 +16,8 @@ import (
 
 //Config describe parameters need to make a connection to a Mongo database
 type Config struct {
-	Scheme                 string                 `json:"scheme"`
-	Addresses              []string               `json:"addresses"`
+	Scheme                 string `json:"scheme"`
+	addresses              []string
 	TLS                    bool                   `json:"tls"`
 	Database               string                 `json:"database"`
 	CollectionPrefix       string                 `json:"collectionPrefix"`
@@ -27,6 +28,7 @@ type Config struct {
 	WaitConnectionInterval time.Duration          `json:"waitConnectionInterval"`
 	MaxConnectionAttempts  int64                  `json:"maxConnectionAttempts"`
 	Indexes                map[string][]mgo.Index `json:"indexes"`
+	adressMux              sync.Mutex
 }
 
 //NewConfig creates and returns an incomplete Config object
@@ -37,6 +39,16 @@ func NewConfig() *Config {
 		WaitConnectionInterval: 5 * time.Second,
 		MaxConnectionAttempts:  0,
 	}
+}
+func (c *Config) Addresses() []string {
+	c.adressMux.Lock()
+	defer c.adressMux.Unlock()
+	return c.addresses
+}
+func (c *Config) SetAddresses(addresses []string) {
+	c.adressMux.Lock()
+	defer c.adressMux.Unlock()
+	c.addresses = addresses
 }
 
 // AsConnectionString constructs a MongoDB connection string from a Config
@@ -56,7 +68,7 @@ func (c *Config) AsConnectionString() string {
 		}
 		url += "@"
 	}
-	url += strings.Join(c.Addresses, ",")
+	url += strings.Join(c.Addresses(), ",")
 	url += "/"
 	url += c.Database
 	if c.TLS {
@@ -77,7 +89,8 @@ func (c *Config) Load(configReporter config.Reporter) error {
 		return errors.New("config reporter is missing")
 	}
 
-	c.Addresses = SplitAddresses(configReporter.GetWithDefault("addresses", strings.Join(c.Addresses, ",")))
+	addresses := SplitAddresses(configReporter.GetWithDefault("addresses", strings.Join(c.Addresses(), ",")))
+	c.SetAddresses(addresses)
 	if tlsString, err := configReporter.Get("tls"); err == nil {
 		var tls bool
 		tls, err = strconv.ParseBool(tlsString)
@@ -127,10 +140,10 @@ func (c *Config) Load(configReporter config.Reporter) error {
 // Validate that all parameters are syntactically valid, that all required parameters are present,
 // and the the URL constructed from those parameters is parseable by the Mongo driver
 func (c *Config) Validate() error {
-	if len(c.Addresses) == 0 {
+	if len(c.Addresses()) == 0 {
 		return errors.New("addresses is missing")
 	}
-	for _, address := range c.Addresses {
+	for _, address := range c.Addresses() {
 		if address == "" {
 			return errors.New("address is missing")
 		} else if _, err := url.Parse(address); err != nil {

--- a/store/structured/mongo/config_test.go
+++ b/store/structured/mongo/config_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Config", func() {
 			datum := storeStructuredMongo.NewConfig()
 			Expect(datum).ToNot(BeNil())
 			Expect(datum.Scheme).To(BeEmpty())
-			Expect(datum.Addresses).To(BeNil())
+			Expect(datum.Addresses()).To(BeNil())
 			Expect(datum.TLS).To(BeTrue())
 			Expect(datum.Database).To(BeEmpty())
 			Expect(datum.CollectionPrefix).To(BeEmpty())
@@ -58,7 +58,7 @@ var _ = Describe("Config", func() {
 			It("uses default addresses if not set", func() {
 				delete(configReporter.Config, "addresses")
 				Expect(config.Load(configReporter)).To(Succeed())
-				Expect(config.Addresses).To(BeEmpty())
+				Expect(config.Addresses()).To(BeEmpty())
 			})
 
 			It("uses default tls if not set", func() {
@@ -112,7 +112,7 @@ var _ = Describe("Config", func() {
 			It("returns successfully and uses values from config reporter", func() {
 				Expect(config.Load(configReporter)).To(Succeed())
 				Expect(config.Scheme).To(Equal("mongodb+srv"))
-				Expect(config.Addresses).To(Equal([]string{"https://1.2.3.4:5678", "http://a.b.c.d:9999"}))
+				Expect(config.Addresses()).To(Equal([]string{"https://1.2.3.4:5678", "http://a.b.c.d:9999"}))
 				Expect(config.TLS).To(BeFalse())
 				Expect(config.Database).To(Equal("database"))
 				Expect(config.CollectionPrefix).To(Equal("collection_prefix"))
@@ -126,7 +126,7 @@ var _ = Describe("Config", func() {
 
 		Context("with valid values", func() {
 			BeforeEach(func() {
-				config.Addresses = []string{"1.2.3.4", "5.6.7.8"}
+				config.SetAddresses([]string{"1.2.3.4", "5.6.7.8"})
 				config.TLS = false
 				config.Database = "database"
 				config.CollectionPrefix = "collection_prefix"
@@ -141,22 +141,22 @@ var _ = Describe("Config", func() {
 				})
 
 				It("returns an error if the addresses is nil", func() {
-					config.Addresses = nil
+					config.SetAddresses(nil)
 					Expect(config.Validate()).To(MatchError("addresses is missing"))
 				})
 
 				It("returns an error if the addresses is empty", func() {
-					config.Addresses = []string{}
+					config.SetAddresses([]string{})
 					Expect(config.Validate()).To(MatchError("addresses is missing"))
 				})
 
 				It("returns an error if one of the addresses is missing", func() {
-					config.Addresses = []string{""}
+					config.SetAddresses([]string{""})
 					Expect(config.Validate()).To(MatchError("address is missing"))
 				})
 
 				It("returns an error if one of the addresses is not a parseable URL", func() {
-					config.Addresses = []string{"Not%Parseable"}
+					config.SetAddresses([]string{"Not%Parseable"})
 					Expect(config.Validate()).To(MatchError("address is invalid"))
 				})
 

--- a/store/structured/mongo/mongo_test.go
+++ b/store/structured/mongo/mongo_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/tidepool-org/platform/log"
 	logTest "github.com/tidepool-org/platform/log/test"
-	"github.com/tidepool-org/platform/pointer"
 	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
 	storeStructuredMongoTest "github.com/tidepool-org/platform/store/structured/mongo/test"
 )
@@ -58,34 +57,35 @@ var _ = Describe("Mongo", func() {
 				Expect(store).To(BeNil())
 			})
 
-			It("returns an error if the addresses are not reachable", func() {
-				config.Addresses = []string{"127.0.0.0", "127.0.0.0"}
-				var err error
-				store, err = storeStructuredMongo.NewStore(config, logger)
-				Expect(err).To(MatchError("unable to dial database; no reachable servers"))
-				Expect(store).To(BeNil())
-			})
+			// It("returns an error if the addresses are not reachable", func() {
+			// 	config.Addresses = []string{"127.0.0.0", "127.0.0.0"}
+			// 	var err error
+			// 	store, err = storeStructuredMongo.NewStore(config, logger)
+			// 	Expect(err).To(MatchError("unable to dial database; no reachable servers"))
+			// 	Expect(store).To(BeNil())
+			// })
 
-			It("returns an error if the username or password is invalid", func() {
-				config.Username = pointer.FromString("username")
-				config.Password = pointer.FromString("password")
-				var err error
-				store, err = storeStructuredMongo.NewStore(config, logger)
-				Expect(err).To(MatchError("unable to dial database; server returned error on SASL authentication step: Authentication failed."))
-				Expect(store).To(BeNil())
-			})
+			// It("returns an error if the username or password is invalid", func() {
+			// 	config.Username = pointer.FromString("username")
+			// 	config.Password = pointer.FromString("password")
+			// 	var err error
+			// 	store, err = storeStructuredMongo.NewStore(config, logger)
+			// 	Expect(err).To(MatchError("unable to dial database; server returned error on SASL authentication step: Authentication failed."))
+			// 	Expect(store).To(BeNil())
+			// })
 
-			It("returns an error if TLS is specified on a server that does not support it", func() {
-				config.TLS = true
-				var err error
-				store, err = storeStructuredMongo.NewStore(config, logger)
-				Expect(err).To(MatchError("unable to dial database; no reachable servers"))
-				Expect(store).To(BeNil())
-			})
+			// It("returns an error if TLS is specified on a server that does not support it", func() {
+			// 	config.TLS = true
+			// 	var err error
+			// 	store, err = storeStructuredMongo.NewStore(config, logger)
+			// 	Expect(err).To(MatchError("unable to dial database; no reachable servers"))
+			// 	Expect(store).To(BeNil())
+			// })
 
 			It("returns no error if successful", func() {
 				var err error
 				store, err = storeStructuredMongo.NewStore(config, logger)
+				store.WaitUntilStarted()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(store).ToNot(BeNil())
 			})
@@ -95,6 +95,7 @@ var _ = Describe("Mongo", func() {
 			BeforeEach(func() {
 				var err error
 				store, err = storeStructuredMongo.NewStore(config, logger)
+				store.WaitUntilStarted()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(store).ToNot(BeNil())
 			})

--- a/store/structured/mongo/mongo_test.go
+++ b/store/structured/mongo/mongo_test.go
@@ -1,6 +1,8 @@
 package mongo_test
 
 import (
+	"time"
+
 	mgo "github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 	. "github.com/onsi/ginkgo"
@@ -57,30 +59,23 @@ var _ = Describe("Mongo", func() {
 				Expect(store).To(BeNil())
 			})
 
-			// It("returns an error if the addresses are not reachable", func() {
-			// 	config.Addresses = []string{"127.0.0.0", "127.0.0.0"}
-			// 	var err error
-			// 	store, err = storeStructuredMongo.NewStore(config, logger)
-			// 	Expect(err).To(MatchError("unable to dial database; no reachable servers"))
-			// 	Expect(store).To(BeNil())
-			// })
+			It("returns no error if the server is not reachable and initialize session once it is", func() {
+				config.Addresses = []string{"127.0.0.0"}
+				config.WaitConnectionInterval = 1 * time.Second
+				config.Timeout = 2 * time.Second
+				var err error
 
-			// It("returns an error if the username or password is invalid", func() {
-			// 	config.Username = pointer.FromString("username")
-			// 	config.Password = pointer.FromString("password")
-			// 	var err error
-			// 	store, err = storeStructuredMongo.NewStore(config, logger)
-			// 	Expect(err).To(MatchError("unable to dial database; server returned error on SASL authentication step: Authentication failed."))
-			// 	Expect(store).To(BeNil())
-			// })
+				store, err = storeStructuredMongo.NewStore(config, logger)
+				Expect(err).To(BeNil())
+				Expect(store).ToNot(BeNil())
+				Expect(store.Session()).To(BeNil())
+				time.Sleep(3 * time.Second)
+				Expect(store.Session()).To(BeNil())
 
-			// It("returns an error if TLS is specified on a server that does not support it", func() {
-			// 	config.TLS = true
-			// 	var err error
-			// 	store, err = storeStructuredMongo.NewStore(config, logger)
-			// 	Expect(err).To(MatchError("unable to dial database; no reachable servers"))
-			// 	Expect(store).To(BeNil())
-			// })
+				store.Config.Addresses = []string{"127.0.0.1:27017"}
+				store.WaitUntilStarted()
+				Expect(store.Session()).ToNot(BeNil())
+			})
 
 			It("returns no error if successful", func() {
 				var err error

--- a/store/structured/mongo/mongo_test.go
+++ b/store/structured/mongo/mongo_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Mongo", func() {
 			})
 
 			It("returns an error if the config is invalid", func() {
-				config.Addresses = nil
+				config.SetAddresses(nil)
 				var err error
 				store, err = storeStructuredMongo.NewStore(config, logger)
 				Expect(err).To(MatchError("config is invalid; addresses is missing"))
@@ -60,7 +60,7 @@ var _ = Describe("Mongo", func() {
 			})
 
 			It("returns no error if the server is not reachable and initialize session once it is", func() {
-				config.Addresses = []string{"127.0.0.0"}
+				config.SetAddresses([]string{"127.0.0.0"})
 				config.WaitConnectionInterval = 1 * time.Second
 				config.Timeout = 2 * time.Second
 				var err error
@@ -72,7 +72,7 @@ var _ = Describe("Mongo", func() {
 				time.Sleep(3 * time.Second)
 				Expect(store.Session()).To(BeNil())
 
-				store.Config.Addresses = []string{"127.0.0.1:27017"}
+				config.SetAddresses([]string{"127.0.0.1:27017"})
 				store.WaitUntilStarted()
 				Expect(store.Session()).ToNot(BeNil())
 			})

--- a/store/structured/mongo/test/config.go
+++ b/store/structured/mongo/test/config.go
@@ -8,10 +8,12 @@ import (
 
 //NewConfig creates a test Mongo configuration
 func NewConfig() *storeStructuredMongo.Config {
-	return &storeStructuredMongo.Config{
-		Addresses:        []string{Address()},
+	conf := &storeStructuredMongo.Config{
 		Database:         Database(),
 		CollectionPrefix: NewCollectionPrefix(),
 		Timeout:          5 * time.Second,
 	}
+	conf.SetAddresses([]string{Address()})
+
+	return conf
 }

--- a/synctask/store/mongo/mongo_test.go
+++ b/synctask/store/mongo/mongo_test.go
@@ -80,6 +80,7 @@ var _ = Describe("Mongo", func() {
 		It("returns a new store and no error if successful", func() {
 			var err error
 			mongoStore, err = synctaskStoreMongo.NewStore(mongoConfig, logTest.NewLogger())
+			mongoStore.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mongoStore).ToNot(BeNil())
 		})
@@ -89,6 +90,7 @@ var _ = Describe("Mongo", func() {
 		BeforeEach(func() {
 			var err error
 			mongoStore, err = synctaskStoreMongo.NewStore(mongoConfig, logTest.NewLogger())
+			mongoStore.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mongoStore).ToNot(BeNil())
 		})

--- a/task/service/service/service.go
+++ b/task/service/service/service.go
@@ -109,13 +109,6 @@ func (s *Service) initializeTaskStore() error {
 	}
 	s.taskStore = taskStore
 
-	s.Logger().Debug("Ensuring task store indexes")
-
-	err = s.taskStore.EnsureIndexes()
-	if err != nil {
-		return errors.Wrap(err, "unable to ensure task store indexes")
-	}
-
 	return nil
 }
 

--- a/task/store/mongo/mongo_test.go
+++ b/task/store/mongo/mongo_test.go
@@ -4,7 +4,6 @@ import (
 	mgo "github.com/globalsign/mgo"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 
 	logTest "github.com/tidepool-org/platform/log/test"
 	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
@@ -49,38 +48,20 @@ var _ = Describe("Mongo", func() {
 
 	Context("with a new store", func() {
 		var mgoSession *mgo.Session
-		var mgoCollection *mgo.Collection
 
 		BeforeEach(func() {
 			var err error
 			str, err = taskStoreMongo.NewStore(cfg, logTest.NewLogger())
+			str.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(str).ToNot(BeNil())
 			mgoSession = storeStructuredMongoTest.Session().Copy()
-			mgoCollection = mgoSession.DB(cfg.Database).C(cfg.CollectionPrefix + "tasks")
 		})
 
 		AfterEach(func() {
 			if mgoSession != nil {
 				mgoSession.Close()
 			}
-		})
-
-		Context("EnsureIndexes", func() {
-			It("returns successfully", func() {
-				Expect(str.EnsureIndexes()).To(Succeed())
-				indexes, err := mgoCollection.Indexes()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(indexes).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("_id")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("id"), "Background": Equal(true), "Unique": Equal(true)}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("name"), "Background": Equal(true), "Unique": Equal(true), "Sparse": Equal(true)}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("priority"), "Background": Equal(true)}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("availableTime"), "Background": Equal(true)}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("expirationTime"), "Background": Equal(true)}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("state"), "Background": Equal(true)}),
-				))
-			})
 		})
 
 		Context("NewTaskSession", func() {

--- a/tool/mongo/tool.go
+++ b/tool/mongo/tool.go
@@ -64,7 +64,7 @@ func (t *Tool) ParseContext(ctx *cli.Context) bool {
 	}
 
 	if ctx.IsSet(AddressesFlag) {
-		t.mongoConfig.Addresses = storeStructuredMongo.SplitAddresses(ctx.String(AddressesFlag))
+		t.mongoConfig.SetAddresses(storeStructuredMongo.SplitAddresses(ctx.String(AddressesFlag)))
 	}
 	if ctx.IsSet(TLSFlag) {
 		t.mongoConfig.TLS = ctx.Bool(TLSFlag)
@@ -75,8 +75,8 @@ func (t *Tool) ParseContext(ctx *cli.Context) bool {
 
 func (t *Tool) NewMongoConfig() *storeStructuredMongo.Config {
 	mongoConfig := storeStructuredMongo.NewConfig()
-	if t.mongoConfig.Addresses != nil {
-		mongoConfig.Addresses = append([]string{}, t.mongoConfig.Addresses...)
+	if t.mongoConfig.Addresses() != nil {
+		mongoConfig.SetAddresses(append([]string{}, t.mongoConfig.Addresses()...))
 	}
 	mongoConfig.TLS = t.mongoConfig.TLS
 	mongoConfig.Database = t.mongoConfig.Database

--- a/tools/benchmark_data_store/benchmark_data_store.go
+++ b/tools/benchmark_data_store/benchmark_data_store.go
@@ -125,7 +125,7 @@ func (t *Tool) ParseContext(ctx *cli.Context) bool {
 	}
 
 	if ctx.IsSet(AddressesFlag) {
-		t.config.Addresses = ctx.StringSlice(AddressesFlag)
+		t.config.SetAddresses(ctx.StringSlice(AddressesFlag))
 	}
 	if ctx.IsSet(DatabaseFlag) {
 		t.config.Database = ctx.String(DatabaseFlag)

--- a/user/service/service.go
+++ b/user/service/service.go
@@ -339,13 +339,6 @@ func (s *Service) initializeConfirmationStore() error {
 	}
 	s.confirmationStore = store
 
-	s.Logger().Debug("Ensuring confirmation store indexes")
-
-	err = s.confirmationStore.EnsureIndexes()
-	if err != nil {
-		return errors.Wrap(err, "unable to ensure confirmation store indexes")
-	}
-
 	return nil
 }
 
@@ -490,13 +483,6 @@ func (s *Service) initializeUserStructuredStore() error {
 		return errors.Wrap(err, "unable to create user structured store")
 	}
 	s.userStructuredStore = userStructuredStore
-
-	s.Logger().Debug("Ensuring user structured store indexes")
-
-	err = s.userStructuredStore.EnsureIndexes()
-	if err != nil {
-		return errors.Wrap(err, "unable to ensure user structured store indexes")
-	}
 
 	return nil
 }

--- a/user/store/structured/mongo/mongo_test.go
+++ b/user/store/structured/mongo/mongo_test.go
@@ -81,6 +81,7 @@ var _ = Describe("Mongo", func() {
 		BeforeEach(func() {
 			var err error
 			store, err = userStoreStructuredMongo.NewStore(config, logger)
+			store.WaitUntilStarted()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(store).ToNot(BeNil())
 			mgoSession = storeStructuredMongoTest.Session().Copy()
@@ -91,18 +92,6 @@ var _ = Describe("Mongo", func() {
 			if mgoSession != nil {
 				mgoSession.Close()
 			}
-		})
-
-		Context("EnsureIndexes", func() {
-			It("returns successfully", func() {
-				Expect(store.EnsureIndexes()).To(Succeed())
-				indexes, err := mgoCollection.Indexes()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(indexes).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("_id")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("userid"), "Background": Equal(true), "Unique": Equal(true)}),
-				))
-			})
 		})
 
 		Context("NewSession", func() {
@@ -116,7 +105,6 @@ var _ = Describe("Mongo", func() {
 			var ctx context.Context
 
 			BeforeEach(func() {
-				Expect(store.EnsureIndexes()).To(Succeed())
 				session = store.NewSession()
 				ctx = log.NewContextWithLogger(context.Background(), logger)
 			})


### PR DESCRIPTION
Database first connection is now launched through a goroutine that doesn't block the service startup. Database session is available once this connection has been established. 
EnsureIndexes methods are also done in the goroutine (that may be the only reason we need connection on startup).

Two new environment variables are introduced :
- TIDEPOOL_STORE_WAIT_CONNECTION_INTERVAL (default 5) wait interval in seconds for the goroutine between failure on the last attempt and next attempt
 - TIDEPOOL_STORE_MAX_CONNECTION_ATTEMPTS (default 0) number of attempts before the goroutine crashes (and so on the service). If this number is <= 0, it will loop infinitely until it is able to connect

