### PR TITLE
YLP-130 Remove "mdblp" from docker image name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The Tidepool platform API
 ## Unreleased
 ### Changed 
 - PT-1332 Remove external gateway calls in platform
+### Engineering
+- YLP-130 Remove "mdblp" from docker image name
 
 ## 0.8.4 2020-08-04 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ else ifdef TRAVIS_TAG
 	DOCKER:=true
 endif
 ifdef DOCKER_FILE
-	DOCKER_REPOSITORY:="${DOCKER_REGISTRY}/mdblp/$(REPOSITORY_NAME)-$(patsubst .%,%,$(suffix $(DOCKER_FILE)))"
+	DOCKER_REPOSITORY:="${DOCKER_REGISTRY}/$(REPOSITORY_NAME)-$(patsubst .%,%,$(suffix $(DOCKER_FILE)))"
 endif
 
 default: test


### PR DESCRIPTION
So we do not have discrepancies with other services, the image name should not be prefixed by "mdblp/". They should contain the name of the service only