### PR TITLE
Feature/add trivy scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,6 @@ services:
   - docker
 
 script:
-  # - make ci-generate ci-build ci-test ci-snyk ci-deploy ci-docker
   - make ci-generate ci-build ci-test ci-deploy ci-docker
   - GO111MODULE="on" make ci-soups
 cache:


### PR DESCRIPTION
Add a new target `docker-scan` to run Trivy security scan on all the built images
The scan is not conditionned by anything (opened to discussion as I think it will be platform-data only and eventually sent to Coreye, so it is scanning each time image is built to fail fast)
In order to test a failing scan, you can tweak the `docker-scan` target to run trivy against image wordpress:4.6.0. The failure will make the process abort. Like the images below show:

![image](https://user-images.githubusercontent.com/33152621/92629621-df31f780-f2ce-11ea-8761-a32f0962aaa7.png)


![image](https://user-images.githubusercontent.com/33152621/92629560-c75a7380-f2ce-11ea-8bef-b2f68437cd7f.png)
