### PR TITLE
Fix wizard update logic to match bolus update logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Platform 
 The data platform API
 
-## 0.26.0-rc1 - 2024-01-31
+## 0.26.0 - 2024-01-31
 ### Fixed 
 - YLP-3111 Restore missing field for wizard written in buckets
 - YLP-2939 I have a duplicate physical activities created when a update is sent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Platform 
 The data platform API
 
-## 0.26.0 - 2024-01-31
+## 0.26.0-rc2 - 2024-01-31
 ### Fixed 
 - YLP-3111 Restore missing field for wizard written in buckets
 - YLP-2939 I have a duplicate physical activities created when a update is sent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Platform 
 The data platform API
 
-## 0.26.0-rc2 - 2024-01-31
+## 0.26.0 - 2024-01-31
 ### Fixed 
 - YLP-3111 Restore missing field for wizard written in buckets
 - YLP-2939 I have a duplicate physical activities created when a update is sent

--- a/data/store/mongo/mongo_bucket_store_client.go
+++ b/data/store/mongo/mongo_bucket_store_client.go
@@ -619,27 +619,31 @@ func buildWizardUpdateOneModel(sample schema.ISample, userId *string, date strin
 
 	// Update
 	elemfilter := sample.(schema.Wizard)
-	secondOp := mongo.NewUpdateOneModel()
-	secondOp.SetFilter(bson.D{
-		{Key: "_id", Value: strUserId + "_" + date},
-		{Key: "meals", Value: bson.D{
-			{Key: "$elemMatch", Value: bson.D{
-				{Key: "timestamp", Value: elemfilter.Timestamp},
+	if elemfilter.Guid != "" && elemfilter.DeviceId != "" {
+		secondOp := mongo.NewUpdateOneModel()
+		secondOp.SetFilter(bson.D{
+			{Key: "_id", Value: strUserId + "_" + date},
+			{Key: "meals", Value: bson.D{
+				{Key: "$elemMatch", Value: bson.D{
+					{Key: "guid", Value: elemfilter.Guid},
+					{Key: "deviceId", Value: elemfilter.DeviceId},
+				},
+				},
 			},
 			},
-		},
-		},
-	})
-	secondOp.SetUpdate(bson.D{ // update
-		{Key: "$set", Value: bson.D{
-			{Key: "meals.$.carbInput", Value: elemfilter.CarbInput},
-			{Key: "meals.$.bolus", Value: elemfilter.BolusId},
-			{Key: "meals.$.inputTimestamp", Value: elemfilter.InputTimestamp},
-		},
-		},
-	})
+		})
+		secondOp.SetUpdate(bson.D{ // update
+			{Key: "$set", Value: bson.D{
+				{Key: "meals.$.carbInput", Value: elemfilter.CarbInput},
+				{Key: "meals.$.bolus", Value: elemfilter.BolusId},
+				{Key: "meals.$.inputTimestamp", Value: elemfilter.InputTimestamp},
+				{Key: "meals.$.uuid", Value: elemfilter.Uuid},
+			},
+			},
+		})
 
-	updates = append(updates, secondOp)
+		updates = append(updates, secondOp)
+	}
 	// Otherwise we know that we did not update, so we guarantee an insertion
 	// in the array
 	thirdOp := mongo.NewUpdateOneModel()


### PR DESCRIPTION
Wizard update logic is not aligned with bolus update logic ... It's breaking yourloops integration tests due to the fact that wizard and bolus were not matching (having more boluses than wizard is breaking the UI).

Broken test SYSTREQ-86 : data loader running two times wizard creation with different values for boluses. With the wizard update logic wizard were updated based on timestamp field but not boluses, resulting in boluses duplicated and not wizard ... breaking UI.